### PR TITLE
fix: improve decode strategy

### DIFF
--- a/src/imageGenerator.js
+++ b/src/imageGenerator.js
@@ -10,6 +10,23 @@ const { RegisterHTMLHandler } = require('mathjax-full/js/handlers/html.js');
 const { AllPackages } = require('mathjax-full/js/input/tex/AllPackages.js');
 const { decode } = require('html-entities');
 
+function robustDecode(input) {
+  let result = input;
+  let prevResult;
+  do {
+    prevResult = result;
+    try {
+      result = decodeURIComponent(prevResult);
+    } catch (e) {
+      // If we hit an invalid URI, use the last valid result
+      result = prevResult;
+      break;
+    }
+  } while (result !== prevResult);
+  
+  // Then decode HTML entities
+  return decode(result);
+}
 
 const adaptor = liteAdaptor();
 RegisterHTMLHandler(adaptor);
@@ -86,8 +103,8 @@ module.exports.generate = async (configs, req, res, next) => {
       console.log('No math provided');
       return handleError(res);
     }
-    // Decode HTML entities in the math input
-    const math = stripRequireCommands(decode(configs.typeset.math));
+    // Use the robust decoder instead of just decode
+    const math = stripRequireCommands(robustDecode(configs.typeset.math));
 
     const isInline = (math.startsWith('\\(') && math.endsWith('\\)')) ||
         (math.startsWith('$') && math.endsWith('$') && !math.startsWith('$$'));


### PR DESCRIPTION
This pull request includes changes to the `src/imageGenerator.js` file to improve the robustness of decoding input strings. The most important changes include the addition of a new `robustDecode` function and the replacement of the existing decode function with this new robust decoder.

Improvements to input decoding:

* [`src/imageGenerator.js`](diffhunk://#diff-1fd64215ef73d65080e09008b5098c82ee2982de2ff7cfca41e62d8fada4f508R13-R29): Added a new `robustDecode` function that attempts to decode URI components repeatedly until no further decoding is possible and then decodes HTML entities.
* [`src/imageGenerator.js`](diffhunk://#diff-1fd64215ef73d65080e09008b5098c82ee2982de2ff7cfca41e62d8fada4f508L89-R107): Replaced the existing decode function with the new `robustDecode` function in the `generate` method to handle input decoding more robustly.

### Solution

This will handle urls like

> https://1ui6ipoe49.execute-api.ca-central-1.amazonaws.com/latest/latex?latex=sum_%7Bi%3D0%7D%5En%20i%5E2%20%3D%20%5Cfrac%7B%28n%5E2%2Bn%29%282n%2B1%29%7D%7B6%7D&fg=000000&svg=1

OR

> https://1ui6ipoe49.execute-api.ca-central-1.amazonaws.com/latest/latex?latex=sum_%257Bi%253D0%257D%255En%2520i%255E2%2520%253D%2520%255Cfrac%257B%2528n%255E2%252Bn%2529%25282n%252B1%2529%257D%257B6%257D&%23038;fg=000000&#038;svg=1