### PR TITLE
fix: mathml % formulas

### DIFF
--- a/src/imageGenerator.js
+++ b/src/imageGenerator.js
@@ -86,11 +86,17 @@ module.exports.generate = async (configs, req, res, next) => {
 
     try {
       // Temporarily encode LaTeX percent signs to avoid issues with decodeURIComponent
-      decodedMath = decodedMath.replace(/\\\%/g, '__PERCENT__');
+       decodedMath = decodedMath.replace(/\\\%/g, "__PERCENT__");
+      // Handle MathML
+      decodedMath = decodedMath.replace(
+        /<(m[a-z]+)>%<\/\1>/g,
+        "<$1>__MATHPERCENT__</$1>",
+      );
       decodedMath = decodeURIComponent(decodedMath);
-      // Restore LaTeX percent signs
-      decodedMath = decodedMath.replace(/__PERCENT__/g, '\\%');
-      decodedMath = decodedMath.replace(/&#038;/g, '&').replace(/&#38;/g, '&');
+      // Restore LaTeX and MathML percent signs
+      decodedMath = decodedMath.replace(/__PERCENT__/g, "\\%");
+      decodedMath = decodedMath.replace(/__MATHPERCENT__/g, "%");
+      decodedMath = decodedMath.replace(/&#038;/g, "&").replace(/&#38;/g, "&");
       decodedMath = decode(decodedMath);
     } catch (decodeError) {
       return handleError(res);


### PR DESCRIPTION
This pull request updates the `generate` function in `src/imageGenerator.js` to improve how percent signs are handled in both LaTeX and MathML content during encoding and decoding. The changes ensure better compatibility and correctness when processing mathematical expressions.

Key changes:

### Improvements to percent sign handling:
* Added support for encoding and decoding MathML percent signs by introducing a new placeholder, `__MATHPERCENT__`, to handle cases like `<mrow>%</mrow>` during processing.
* Refined the restoration process to handle both LaTeX (`__PERCENT__`) and MathML (`__MATHPERCENT__`) percent sign placeholders, ensuring accurate decoding for both formats.

Associated PB PR https://github.com/pressbooks/pressbooks/pull/4088